### PR TITLE
fix: support graceful termination of a indy node

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -28,4 +28,4 @@ check_argument "$NODE_CLIENT_IP" "NODE_CLIENT_IP"
 check_argument "$NODE_CLIENT_PORT" "NODE_CLIENT_PORT"
 
 # start the node
-/usr/bin/env python3 -O /usr/local/bin/start_indy_node "$NODE_NAME" "$NODE_IP" "$NODE_PORT" "$NODE_CLIENT_IP" "$NODE_CLIENT_PORT"
+exec /usr/bin/env python3 -O /usr/local/bin/start_indy_node "$NODE_NAME" "$NODE_IP" "$NODE_PORT" "$NODE_CLIENT_IP" "$NODE_CLIENT_PORT"


### PR DESCRIPTION
This will replace the current bash process with the real python PID. So that no zombie processes can happen after a docker stop or docker kill.